### PR TITLE
Add pipeline lock data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Terraform Provider
 
-- Website: https://www.terraform.io
+- Provider Publishing: https://registry.terraform.io/providers/homedepot/spinnaker/latest/docs
 - [![Gitter chat](https://badges.gitter.im/hashicorp-terraform/Lobby.png)](https://gitter.im/hashicorp-terraform/Lobby)
 - Mailing list: [Google Groups](http://groups.google.com/group/terraform-tool)
 

--- a/docs/data-sources/spinnaker_pipeline.md
+++ b/docs/data-sources/spinnaker_pipeline.md
@@ -13,9 +13,9 @@ provider "spinnaker" {
     server = "http://spinnaker-gate.myorg.io"
 }
 
-data "spinnaker_application" "terraform_example" {
+data "spinnaker_pipeline" "pipeline_example" {
     application = "terraformexample"
-    email       = "user@example.com"
+    name        = "Example Pipeline"
 }
 ```
 

--- a/docs/data-sources/spinnaker_pipeline_add_lock.md
+++ b/docs/data-sources/spinnaker_pipeline_add_lock.md
@@ -1,0 +1,33 @@
+---
+page_title: "spinnaker_pipeline_add_lock"
+---
+
+# spinnaker_pipeline_add_lock Data Source
+
+Add lock to spinnaker pipeline resource
+
+## Example Usage
+
+```
+provider "spinnaker" {
+    server = "http://spinnaker-gate.myorg.io"
+}
+
+data "spinnaker_pipeline_add_lock" "example_pipeline" {
+    pipeline = file ("/path/to/pipeline/pipeline.json")
+}
+```
+
+## Argument Reference
+
+- `pipeline` - (Required) Pipeline json.
+- `ui` - (Optional) Unknown behavior or ignored by Spinnaker. (Default: `true`)
+- `allow_unlock_ui` - (Optional) If set to true means pipelibe can be unlocked from inside the Spinnaker UI (deck). If set to false, then all changes to the pipeline must be done thru API. (Default: `true`)
+- `description` - (Optional) Reason shown in Spinnaker UI (deck) for pipeline to be locked (Default: No default unless environment variables are set, then `"Maintained in $GITHUB_SERVER_URL/$GITHUB_REPOSITORY"` or `"Maintained in repo: $GITHUB_REPOSITORY"`).
+
+## Attribute Reference
+
+In addition to the above, the following attributes are exported:
+
+- `rendered` - Pipeline JSON after lock is added.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ resource "spinnaker_application" "terraform_example" {
     email       = "user@example.com"
 }
 
-resource "spinnaker_pipeline" "terraform_example" {
+resource "spinnaker_pipeline" "pipeline_example" {
     application = spinnaker_application.terraform_example.application
     name        = "Example Pipeline"
     pipeline    = file("pipelines/example.json")

--- a/spinnaker/datasource_pipeline_add_lock.go
+++ b/spinnaker/datasource_pipeline_add_lock.go
@@ -1,0 +1,97 @@
+package spinnaker
+
+import (
+   "crypto/sha256"
+   "encoding/json"
+   "encoding/hex"
+   "os"
+
+   "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func datasourcePipelineAddLock() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"pipeline": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validatePipelineJson,
+            Description:  "Pipeline json",
+			},
+			"ui": {
+				Type:         schema.TypeBool,
+				Optional:     true,
+            Default:      true,
+            Description:  "Unknown behavior or ignored by Spinnaker.",
+			},
+			"allow_unlock_ui": {
+				Type:         schema.TypeBool,
+				Optional:     true,
+            Default:      true,
+            Description:  "If set to true means pipelibe can be unlocked from inside the Spinnaker UI (deck). If set to false, then all changes to the pipeline must be done thru API.",
+			},
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+            DefaultFunc:  getLockedDescription,
+            Description:  "Reason shown in Spinnaker UI (deck) for pipeline to be locked.",
+			},
+			"rendered": {
+				Type:         schema.TypeString,
+				Computed:     true,
+            Description:  "Pipeline JSON after lock is added.",
+			},
+		},
+		Read: datasourcePipelineAddLockRead,
+	}
+}
+
+func datasourcePipelineAddLockRead(data *schema.ResourceData, meta interface{}) error {
+   pipelineBlob := []byte( data.Get("pipeline").(string) )
+   ui := data.Get("ui").(bool)
+   allowUnlockUi := data.Get("allow_unlock_ui").(bool)
+   description := data.Get("description").(string)
+
+   var pipeline_map map[string]interface{}
+
+   err := json.Unmarshal(pipelineBlob, &pipeline_map)
+   if err != nil {
+      return err
+   }
+
+   // remove "locked" if exists
+   delete (pipeline_map, "locked")
+
+   // add "locked"
+   if len(description) > 0 {
+      pipeline_map["locked"] = map[string]interface{}{ "ui":ui, "allowUnlockUi": allowUnlockUi, "description": description }
+   } else {
+      pipeline_map["locked"] = map[string]interface{}{ "ui":ui, "allowUnlockUi": allowUnlockUi }
+   }
+
+   b, err := json.Marshal(pipeline_map)
+   if err != nil {
+      return err
+   }
+   err = data.Set("rendered", string(b))
+   if err != nil {
+      return err
+   }
+   sha := sha256.Sum256(b)
+   data.SetId(hex.EncodeToString(sha[:]))
+   
+   return nil
+}
+
+func getLockedDescription() (v interface{}, err error) {
+   repo := os.Getenv("GITHUB_REPOSITORY")
+   baseUrl := os.Getenv("GITHUB_SERVER_URL")
+   if len(repo) > 0 {
+      if len(baseUrl) > 0 {
+         v = "Maintained in "+baseUrl+"/"+repo
+      } else {
+         v = "Maintained in repo: "+repo
+      }
+   }
+   return
+}

--- a/spinnaker/provider.go
+++ b/spinnaker/provider.go
@@ -58,6 +58,7 @@ func Provider() *schema.Provider {
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"spinnaker_pipeline": datasourcePipeline(),
+         "spinnaker_pipeline_add_lock": datasourcePipelineAddLock(),
 		},
 		ConfigureFunc: providerConfigureFunc,
 	}

--- a/spinnaker/validators.go
+++ b/spinnaker/validators.go
@@ -1,6 +1,7 @@
 package spinnaker
 
 import (
+   "encoding/json"
 	"fmt"
 	"regexp"
 )
@@ -12,3 +13,12 @@ func validateApplicationName(v interface{}, k string) (ws []string, errors []err
 	}
 	return
 }
+
+func validatePipelineJson(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+   if !json.Valid([]byte(value)) {
+      errors = append(errors, fmt.Errorf("Not valid JSON"))
+   }
+	return
+}
+


### PR DESCRIPTION
- Add locked data source. Dynamic add `locked` node to pipeline JSON:

```
    "locked": {
         "allowUnlockUi": true,
         "description": "Maintained in https://github.com/one-thd/de-cd",
         "ui": true
    }
```