### PR TITLE
[CN-3737] increase wait time for application creation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Unshallow
         run: git fetch --prune --unshallow
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
       - name: Test
@@ -30,10 +30,10 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.TERRAFORM_GPG_PRIVATE_KEY }}
           PASSPHRASE: ${{ secrets.TERRAFORM_GPG_PASSPHRASE }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release --rm-dist --skip-publish --snapshot
+          args: release --clean --snapshot
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Unshallow
         run: git fetch --prune --unshallow
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
       - name: Test
@@ -26,10 +26,10 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.TERRAFORM_GPG_PRIVATE_KEY }}
           PASSPHRASE: ${{ secrets.TERRAFORM_GPG_PASSPHRASE }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/main.go
+++ b/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-   "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-   "github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 
-   "terraform-provider-spinnaker/spinnaker"
+	"terraform-provider-spinnaker/spinnaker"
 )
 
 func main() {

--- a/spinnaker/api/pipeline.go
+++ b/spinnaker/api/pipeline.go
@@ -12,7 +12,7 @@ func CreatePipeline(client *gate.GatewayClient, pipeline interface{}) error {
 	resp, err := client.PipelineControllerApi.SavePipelineUsingPOST(client.Context, pipeline, nil)
 
 	if err != nil {
-		return FormatAPIErrorMessage ("PipelineControllerApi.SavePipelineUsingPOST", err)
+		return FormatAPIErrorMessage("PipelineControllerApi.SavePipelineUsingPOST", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
@@ -33,7 +33,7 @@ func GetPipeline(client *gate.GatewayClient, applicationName, pipelineName strin
 		}
 		return jsonMap, fmt.Errorf("Encountered an error getting pipeline %s, %s\n",
 			pipelineName,
-			FormatAPIErrorMessage ("PipelineControllerApi.GetPipelineConfigUsingGET", err))
+			FormatAPIErrorMessage("PipelineControllerApi.GetPipelineConfigUsingGET", err))
 	}
 
 	if resp.StatusCode != http.StatusOK {
@@ -58,7 +58,7 @@ func UpdatePipeline(client *gate.GatewayClient, pipelineID string, pipeline inte
 	_, resp, err := client.PipelineControllerApi.UpdatePipelineUsingPUT(client.Context, pipelineID, pipeline)
 
 	if err != nil {
-		return FormatAPIErrorMessage ("PipelineControllerApi.UpdatePipelineUsingPUT", err)
+		return FormatAPIErrorMessage("PipelineControllerApi.UpdatePipelineUsingPUT", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
@@ -72,7 +72,7 @@ func DeletePipeline(client *gate.GatewayClient, applicationName, pipelineName st
 	resp, err := client.PipelineControllerApi.DeletePipelineUsingDELETE(client.Context, applicationName, pipelineName)
 
 	if err != nil {
-		return FormatAPIErrorMessage ("PipelineControllerApi.DeletePipelineUsingDELETE", err)
+		return FormatAPIErrorMessage("PipelineControllerApi.DeletePipelineUsingDELETE", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {


### PR DESCRIPTION
## Summary
This change updates the polling mechanism to use exponential backoff with a quadratic increase in wait time between API calls, for a maximum of 20 minutes. The sleep duration is capped at 30 seconds to prevent excessive delays.

### Example
For successive attempts:

Attempt 1: Sleep 1 second.
Attempt 2: Sleep 4 seconds.
Attempt 3: Sleep 9 seconds.
Attempt 6+: Sleep capped at 30 seconds.

## Testing
### Error returned after max attempts reached
<img width="1725" alt="fail" src="https://github.com/user-attachments/assets/53cf819a-f307-4d1b-95a1-8fa0af9827a5">

### Successful after 10 minutes
<img width="797" alt="success" src="https://github.com/user-attachments/assets/83365d17-cbaf-4ea9-a5df-fb287e941fb1">

